### PR TITLE
Add Flask prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,23 @@
-# filemaster placeholder
+# FileMaster Prototype
+
+This is a minimal prototype for a web application that allows a sales agent to request information from a client via a unique link. Clients do not need accounts; each request is accessed using a tokenized URL.
+
+## Features
+
+- List of requested items with completion status
+- Upload files or answer simple forms
+- Example route `/create_dummy` to generate a sample request
+
+## Running
+
+1. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Start the server:
+   ```bash
+   python app.py
+   ```
+3. Navigate to `http://localhost:5000/create_dummy` to create a sample request. The page will output a tokenized link to access the request page.
+
+This prototype uses SQLite for storage and saves uploaded files to the `uploads/` directory.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,55 @@
+from flask import Flask, render_template, request, redirect, url_for
+from models import db, ClientRequest, Module
+import os
+import uuid
+
+app = Flask(__name__)
+app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///filemaster.db'
+app.config['SECRET_KEY'] = 'dev'
+app.config['UPLOAD_FOLDER'] = 'uploads'
+
+db.init_app(app)
+
+@app.before_first_request
+def create_tables():
+    db.create_all()
+
+@app.route('/create_dummy')
+def create_dummy():
+    """Create a dummy request with a couple modules and return the token."""
+    token = uuid.uuid4().hex
+    req = ClientRequest(token=token)
+    mod1 = Module(request=req, kind='file', description='Upload proof of income')
+    mod2 = Module(request=req, kind='form', description='Provide credit score')
+    db.session.add_all([req, mod1, mod2])
+    db.session.commit()
+    return f"Created request with token: {token}\nVisit /request/{token} to view it."
+
+@app.route('/request/<token>')
+def view_request(token):
+    req = ClientRequest.query.filter_by(token=token).first_or_404()
+    selected_id = request.args.get('module')
+    selected = Module.query.get(selected_id) if selected_id else None
+    if not selected:
+        selected = next((m for m in req.modules if not m.completed), None)
+    return render_template('request.html', req=req, selected=selected)
+
+@app.route('/module/<int:module_id>', methods=['POST'])
+def handle_module(module_id):
+    module = Module.query.get_or_404(module_id)
+    if module.kind == 'file':
+        f = request.files.get('file')
+        if f:
+            os.makedirs(app.config['UPLOAD_FOLDER'], exist_ok=True)
+            fname = f"{uuid.uuid4().hex}_{f.filename}"
+            f.save(os.path.join(app.config['UPLOAD_FOLDER'], fname))
+            module.completed = True
+    elif module.kind == 'form':
+        answer = request.form.get('answer')
+        if answer:
+            module.completed = True
+    db.session.commit()
+    return redirect(url_for('view_request', token=module.request.token))
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/models.py
+++ b/models.py
@@ -1,0 +1,20 @@
+from flask_sqlalchemy import SQLAlchemy
+
+
+# SQLAlchemy database instance
+
+db = SQLAlchemy()
+
+
+class ClientRequest(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    token = db.Column(db.String(64), unique=True, nullable=False)
+    modules = db.relationship('Module', backref='request', lazy=True)
+
+
+class Module(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    request_id = db.Column(db.Integer, db.ForeignKey('client_request.id'), nullable=False)
+    kind = db.Column(db.String(10))  # 'file' or 'form'
+    description = db.Column(db.String(255))
+    completed = db.Column(db.Boolean, default=False)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+Flask
+Flask-SQLAlchemy

--- a/static/style.css
+++ b/static/style.css
@@ -1,0 +1,4 @@
+body {font-family: Arial, sans-serif;}
+.layout {display: flex;}
+.queue {width: 40%; padding:1em; border-right: 1px solid #ccc;}
+.module {flex:1; padding:1em;}

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html>
+<head>
+    <title>FileMaster</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+</head>
+<body>
+    <div class="container">
+        {% block content %}{% endblock %}
+    </div>
+</body>
+</html>

--- a/templates/request.html
+++ b/templates/request.html
@@ -1,0 +1,35 @@
+{% extends 'base.html' %}
+{% block content %}
+<div class="layout">
+    <div class="queue">
+        <h2>Requested Items</h2>
+        <ul>
+        {% for m in req.modules %}
+            <li>
+            {% if m.completed %}&#10003;{% else %}&#9633;{% endif %}
+            <a href="{{ url_for('view_request', token=req.token, module=m.id) }}">{{ m.description }}</a>
+            </li>
+        {% endfor %}
+        </ul>
+    </div>
+    <div class="module">
+        {% if selected %}
+            {% if selected.kind == 'file' %}
+            <form action="{{ url_for('handle_module', module_id=selected.id) }}" method="post" enctype="multipart/form-data">
+                <p>{{ selected.description }}</p>
+                <input type="file" name="file" required>
+                <button type="submit">Upload</button>
+            </form>
+            {% elif selected.kind == 'form' %}
+            <form action="{{ url_for('handle_module', module_id=selected.id) }}" method="post">
+                <p>{{ selected.description }}</p>
+                <textarea name="answer" required></textarea>
+                <button type="submit">Submit</button>
+            </form>
+            {% endif %}
+        {% else %}
+            <p>All tasks complete!</p>
+        {% endif %}
+    </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add a simple Flask prototype with SQLAlchemy models
- support creating a dummy request and completing modules
- provide basic templates and styling
- document project setup

## Testing
- `python -m py_compile app.py models.py`
- `pip install -r requirements.txt` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_684484e4ca84832591ac0f795f756bce