### PR TITLE
Add upload size limit and file type validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,4 @@ This is a minimal prototype for a web application that allows a sales agent to r
 3. Navigate to `http://localhost:7777/create_dummy` to create a sample request. The page will output a tokenized link to access the request page.
 
 This prototype uses SQLite for storage and saves uploaded files to the `uploads/` directory.
+Uploads are limited to 10MB and the server only accepts PDF or common image files.

--- a/app.py
+++ b/app.py
@@ -1,5 +1,6 @@
 from flask import Flask, render_template, request, redirect, url_for
 from models import db, ClientRequest, Module
+from werkzeug.utils import secure_filename
 import os
 import uuid
 
@@ -7,6 +8,18 @@ app = Flask(__name__)
 app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///filemaster.db'
 app.config['SECRET_KEY'] = 'dev'
 app.config['UPLOAD_FOLDER'] = 'uploads'
+app.config['MAX_CONTENT_LENGTH'] = 10 * 1024 * 1024  # 10MB limit
+
+ALLOWED_EXTENSIONS = {'pdf', 'png', 'jpg', 'jpeg'}
+ALLOWED_MIMETYPES = {'application/pdf', 'image/png', 'image/jpeg'}
+
+
+def allowed_file(filename, mimetype):
+    return (
+        '.' in filename
+        and filename.rsplit('.', 1)[1].lower() in ALLOWED_EXTENSIONS
+        and mimetype in ALLOWED_MIMETYPES
+    )
 
 db.init_app(app)
 
@@ -38,9 +51,9 @@ def handle_module(module_id):
     module = Module.query.get_or_404(module_id)
     if module.kind == 'file':
         f = request.files.get('file')
-        if f:
+        if f and allowed_file(f.filename, f.mimetype):
             os.makedirs(app.config['UPLOAD_FOLDER'], exist_ok=True)
-            fname = f"{uuid.uuid4().hex}_{f.filename}"
+            fname = f"{uuid.uuid4().hex}_{secure_filename(f.filename)}"
             f.save(os.path.join(app.config['UPLOAD_FOLDER'], fname))
             module.completed = True
     elif module.kind == 'form':


### PR DESCRIPTION
## Summary
- limit Flask uploads to 10MB
- validate uploaded file type and extension before saving
- update documentation for new limits

## Testing
- `python -m py_compile app.py models.py`

------
https://chatgpt.com/codex/tasks/task_e_684497dd86488325b6dd0c189e0d49f6