### PR TITLE
Add admin listing of client requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This is a minimal prototype for a web application that allows a sales agent to r
 - List of requested items with completion status
 - Upload files or answer simple forms
 - Example route `/create_dummy` to generate a sample request
+- Staff route `/admin/requests` to view request tokens and completion status
 
 ## Running
 

--- a/app.py
+++ b/app.py
@@ -24,6 +24,17 @@ def create_dummy():
     db.session.commit()
     return f"Created request with token: {token}\nVisit /request/{token} to view it."
 
+
+@app.route('/admin/requests')
+def list_requests():
+    """List all client requests with completion status."""
+    reqs = []
+    for r in ClientRequest.query.all():
+        total = len(r.modules)
+        completed = sum(1 for m in r.modules if m.completed)
+        reqs.append({'token': r.token, 'completed': completed, 'total': total})
+    return render_template('admin_requests.html', requests=reqs)
+
 @app.route('/request/<token>')
 def view_request(token):
     req = ClientRequest.query.filter_by(token=token).first_or_404()

--- a/templates/admin_requests.html
+++ b/templates/admin_requests.html
@@ -1,0 +1,13 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Client Requests</h2>
+<table>
+    <tr><th>Token</th><th>Status</th></tr>
+    {% for r in requests %}
+    <tr>
+        <td>{{ r.token }}</td>
+        <td>{{ r.completed }}/{{ r.total }} complete</td>
+    </tr>
+    {% endfor %}
+</table>
+{% endblock %}


### PR DESCRIPTION
## Summary
- provide a `/admin/requests` route to view tokens and completion status
- display the information in a new template
- mention the admin route in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684497e7431c8325be5c6d933401ca82