### PR TITLE
Add expiration dates to client requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This is a minimal prototype for a web application that allows a sales agent to r
 - List of requested items with completion status
 - Upload files or answer simple forms
 - Example route `/create_dummy` to generate a sample request
+- Optional expiration dates for requests using the `days` parameter
 
 ## Running
 
@@ -18,6 +19,8 @@ This is a minimal prototype for a web application that allows a sales agent to r
    ```bash
    python app.py
    ```
-3. Navigate to `http://localhost:7777/create_dummy` to create a sample request. The page will output a tokenized link to access the request page.
+3. Navigate to `http://localhost:7777/create_dummy` to create a sample request. Add
+   `?days=<n>` to set an expiration `n` days in the future. The page will output
+   a tokenized link to access the request page.
 
 This prototype uses SQLite for storage and saves uploaded files to the `uploads/` directory.

--- a/app.py
+++ b/app.py
@@ -2,6 +2,7 @@ from flask import Flask, render_template, request, redirect, url_for
 from models import db, ClientRequest, Module
 import os
 import uuid
+from datetime import datetime, timedelta
 
 app = Flask(__name__)
 app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///filemaster.db'
@@ -16,8 +17,10 @@ with app.app_context():
 @app.route('/create_dummy')
 def create_dummy():
     """Create a dummy request with a couple modules and return the token."""
+    days = request.args.get('days', type=int)
+    expires_at = datetime.utcnow() + timedelta(days=days) if days else None
     token = uuid.uuid4().hex
-    req = ClientRequest(token=token)
+    req = ClientRequest(token=token, expires_at=expires_at)
     mod1 = Module(request=req, kind='file', description='Upload proof of income')
     mod2 = Module(request=req, kind='form', description='Provide credit score')
     db.session.add_all([req, mod1, mod2])
@@ -27,6 +30,8 @@ def create_dummy():
 @app.route('/request/<token>')
 def view_request(token):
     req = ClientRequest.query.filter_by(token=token).first_or_404()
+    if req.expires_at and datetime.utcnow() > req.expires_at:
+        return "This request has expired", 404
     selected_id = request.args.get('module')
     selected = Module.query.get(selected_id) if selected_id else None
     if not selected:

--- a/models.py
+++ b/models.py
@@ -1,4 +1,5 @@
 from flask_sqlalchemy import SQLAlchemy
+from datetime import datetime
 
 
 # SQLAlchemy database instance
@@ -9,6 +10,7 @@ db = SQLAlchemy()
 class ClientRequest(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     token = db.Column(db.String(64), unique=True, nullable=False)
+    expires_at = db.Column(db.DateTime, nullable=True)
     modules = db.relationship('Module', backref='request', lazy=True)
 
 


### PR DESCRIPTION
## Summary
- add `expires_at` column to `ClientRequest`
- allow `/create_dummy` to set expiration with a `days` query parameter
- show a friendly message when a request is expired
- document new expiration feature in the README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684497e9a7548325aea32e5e51bbd2ed