### PR TITLE
Add module handler registry

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,4 +1,4 @@
-from flask import Flask, render_template, request, redirect, url_for
+from flask import Flask, render_template, request, redirect, url_for, abort
 from models import db, ClientRequest, Module
 import os
 import uuid
@@ -9,6 +9,39 @@ app.config['SECRET_KEY'] = 'dev'
 app.config['UPLOAD_FOLDER'] = 'uploads'
 
 db.init_app(app)
+
+
+class FileModuleHandler:
+    template = 'modules/file.html'
+
+    def render(self, module):
+        return render_template(self.template, module=module)
+
+    def process(self, module):
+        f = request.files.get('file')
+        if f:
+            os.makedirs(app.config['UPLOAD_FOLDER'], exist_ok=True)
+            fname = f"{uuid.uuid4().hex}_{f.filename}"
+            f.save(os.path.join(app.config['UPLOAD_FOLDER'], fname))
+            module.completed = True
+
+
+class FormModuleHandler:
+    template = 'modules/form.html'
+
+    def render(self, module):
+        return render_template(self.template, module=module)
+
+    def process(self, module):
+        answer = request.form.get('answer')
+        if answer:
+            module.completed = True
+
+
+MODULE_HANDLERS = {
+    'file': FileModuleHandler(),
+    'form': FormModuleHandler(),
+}
 
 with app.app_context():
     db.create_all()
@@ -31,22 +64,21 @@ def view_request(token):
     selected = Module.query.get(selected_id) if selected_id else None
     if not selected:
         selected = next((m for m in req.modules if not m.completed), None)
-    return render_template('request.html', req=req, selected=selected)
+    module_html = None
+    if selected:
+        handler = MODULE_HANDLERS.get(selected.kind)
+        if not handler:
+            abort(400, "Unknown module type")
+        module_html = handler.render(selected)
+    return render_template('request.html', req=req, selected=selected, module_html=module_html)
 
 @app.route('/module/<int:module_id>', methods=['POST'])
 def handle_module(module_id):
     module = Module.query.get_or_404(module_id)
-    if module.kind == 'file':
-        f = request.files.get('file')
-        if f:
-            os.makedirs(app.config['UPLOAD_FOLDER'], exist_ok=True)
-            fname = f"{uuid.uuid4().hex}_{f.filename}"
-            f.save(os.path.join(app.config['UPLOAD_FOLDER'], fname))
-            module.completed = True
-    elif module.kind == 'form':
-        answer = request.form.get('answer')
-        if answer:
-            module.completed = True
+    handler = MODULE_HANDLERS.get(module.kind)
+    if not handler:
+        abort(400, "Unknown module type")
+    handler.process(module)
     db.session.commit()
     return redirect(url_for('view_request', token=module.request.token))
 

--- a/templates/modules/file.html
+++ b/templates/modules/file.html
@@ -1,0 +1,5 @@
+<form action="{{ url_for('handle_module', module_id=module.id) }}" method="post" enctype="multipart/form-data">
+    <p>{{ module.description }}</p>
+    <input type="file" name="file" required>
+    <button type="submit">Upload</button>
+</form>

--- a/templates/modules/form.html
+++ b/templates/modules/form.html
@@ -1,0 +1,5 @@
+<form action="{{ url_for('handle_module', module_id=module.id) }}" method="post">
+    <p>{{ module.description }}</p>
+    <textarea name="answer" required></textarea>
+    <button type="submit">Submit</button>
+</form>

--- a/templates/request.html
+++ b/templates/request.html
@@ -14,19 +14,7 @@
     </div>
     <div class="module">
         {% if selected %}
-            {% if selected.kind == 'file' %}
-            <form action="{{ url_for('handle_module', module_id=selected.id) }}" method="post" enctype="multipart/form-data">
-                <p>{{ selected.description }}</p>
-                <input type="file" name="file" required>
-                <button type="submit">Upload</button>
-            </form>
-            {% elif selected.kind == 'form' %}
-            <form action="{{ url_for('handle_module', module_id=selected.id) }}" method="post">
-                <p>{{ selected.description }}</p>
-                <textarea name="answer" required></textarea>
-                <button type="submit">Submit</button>
-            </form>
-            {% endif %}
+            {{ module_html|safe }}
         {% else %}
             <p>All tasks complete!</p>
         {% endif %}


### PR DESCRIPTION
## Summary
- add Module kind handler classes and registry
- delegate view and submit actions to handlers
- simplify module section of request page
- add dedicated templates for file and form modules

## Testing
- `python -m py_compile app.py models.py`


------
https://chatgpt.com/codex/tasks/task_e_684497ec33d88325920d0de39402b528