### PR TITLE
Add landing page with index route

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ This is a minimal prototype for a web application that allows a sales agent to r
 4. Navigate to `http://localhost:7777/create_dummy` to create a sample request. Add
    `?days=<n>` to set an expiration `n` days in the future. The page will output
    a tokenized link to access the request page.
+5. Visit `http://localhost:7777/` to see the landing page which links to the
+   `/create_dummy` route and other pages.
 
 This prototype uses SQLite for storage and saves uploaded files to the `uploads/` directory.
 Uploads are limited to 10MB and the server only accepts PDF or common image files.

--- a/app.py
+++ b/app.py
@@ -66,6 +66,12 @@ MODULE_HANDLERS = {
     'form': FormModuleHandler(),
 }
 
+
+@app.route('/')
+def index():
+    """Landing page with links to common actions."""
+    return render_template('index.html')
+
 @app.route('/create_dummy')
 def create_dummy():
     """Create a dummy request with a couple modules and return the token."""

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,9 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Welcome to FileMaster</h2>
+<p>This prototype demonstrates simple client file requests.</p>
+<ul>
+  <li><a href="{{ url_for('create_dummy') }}">Create dummy request</a></li>
+  <li><a href="{{ url_for('list_requests') }}">Admin request list</a></li>
+</ul>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add `/` route rendering new index page
- create `index.html` template extending `base.html`
- include screenshot of landing page and update README with instructions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6844b5cddd048325a10ae30ede54e5b1