### PR TITLE
Add expiration info on request page

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -2,3 +2,11 @@ body {font-family: Arial, sans-serif;}
 .layout {display: flex;}
 .queue {width: 40%; padding:1em; border-right: 1px solid #ccc;}
 .module {flex:1; padding:1em;}
+
+.expiration {
+    margin-top: 1em;
+    padding: 0.5em;
+    background: #fffae6;
+    border: 1px solid #f0c36d;
+    font-weight: bold;
+}

--- a/templates/request.html
+++ b/templates/request.html
@@ -11,6 +11,13 @@
             </li>
         {% endfor %}
         </ul>
+        {% if req.expires_at %}
+            <p class="expiration">
+                Expires {{ req.expires_at.strftime('%Y-%m-%d %H:%M UTC') }}
+            </p>
+        {% else %}
+            <p class="expiration">No expiration.</p>
+        {% endif %}
     </div>
     <div class="module">
         {% if selected %}


### PR DESCRIPTION
## Summary
- display expiration info on the request page
- add styling so the notice stands out

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844b5cee4e88325b6c1cd820adbbc42