### PR TITLE
Add module data fields and admin detail page

### DIFF
--- a/migrations/versions/09a08d6fa0c2_add_module_data.py
+++ b/migrations/versions/09a08d6fa0c2_add_module_data.py
@@ -1,0 +1,25 @@
+"""add module data fields
+
+Revision ID: 09a08d6fa0c2
+Revises: 3fe570611070
+Create Date: 2025-06-07 20:35:00.000000
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = '09a08d6fa0c2'
+down_revision = '3fe570611070'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('module', sa.Column('file_path', sa.String(length=255), nullable=True))
+    op.add_column('module', sa.Column('answer', sa.Text(), nullable=True))
+
+
+def downgrade():
+    op.drop_column('module', 'answer')
+    op.drop_column('module', 'file_path')

--- a/models.py
+++ b/models.py
@@ -20,3 +20,5 @@ class Module(db.Model):
     kind = db.Column(db.String(10))  # 'file' or 'form'
     description = db.Column(db.String(255))
     completed = db.Column(db.Boolean, default=False)
+    file_path = db.Column(db.String(255))
+    answer = db.Column(db.Text)

--- a/templates/admin_request_detail.html
+++ b/templates/admin_request_detail.html
@@ -1,0 +1,21 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Request {{ req.token }}</h2>
+<table>
+    <tr><th>Description</th><th>Status</th><th>Data</th></tr>
+    {% for m in req.modules %}
+    <tr>
+        <td>{{ m.description }}</td>
+        <td>{{ 'Complete' if m.completed else 'Incomplete' }}</td>
+        <td>
+        {% if m.file_path %}
+            <a href="{{ url_for('uploaded_file', filename=m.file_path) }}">Download file</a>
+        {% elif m.answer %}
+            {{ m.answer }}
+        {% else %}-{% endif %}
+        </td>
+    </tr>
+    {% endfor %}
+</table>
+<a href="{{ url_for('list_requests') }}">Back to requests</a>
+{% endblock %}

--- a/templates/admin_requests.html
+++ b/templates/admin_requests.html
@@ -5,7 +5,7 @@
     <tr><th>Token</th><th>Status</th></tr>
     {% for r in requests %}
     <tr>
-        <td>{{ r.token }}</td>
+        <td><a href="{{ url_for('admin_request_detail', token=r.token) }}">{{ r.token }}</a></td>
         <td>{{ r.completed }}/{{ r.total }} complete</td>
     </tr>
     {% endfor %}


### PR DESCRIPTION
## Summary
- store uploaded files and answers on modules
- generate Alembic migration for new columns
- populate `file_path` and `answer` when modules are completed
- add admin request detail view and download route
- link admin request listing to detail pages

## Testing
- `python -m py_compile app.py models.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844b5d007988325b986835057e94d0c