### PR TITLE
Fix Alembic migration chain

### DIFF
--- a/migrations/versions/51d4dc079555_add_access_log_model.py
+++ b/migrations/versions/51d4dc079555_add_access_log_model.py
@@ -1,7 +1,7 @@
 """add access log model
 
 Revision ID: 51d4dc079555
-Revises: 3fe570611070
+Revises: 09a08d6fa0c2
 Create Date: 2025-06-07 21:59:02.150649
 
 """
@@ -11,7 +11,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = '51d4dc079555'
-down_revision = '3fe570611070'
+down_revision = '09a08d6fa0c2'
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
## Summary
- fix down_revision in `add_access_log_model.py` to depend on the previous migration

This corrects multiple Alembic heads which caused the server to fail during automatic migration on startup.

## Testing
- `pip install -r requirements.txt`
- `python app.py`

------
https://chatgpt.com/codex/tasks/task_e_6844c01c298883259869239d35adb6db