### PR TITLE
Enable Alpine.js progress UI for request pages

### DIFF
--- a/app.py
+++ b/app.py
@@ -102,7 +102,18 @@ def view_request(token):
     )
     db.session.commit()
 
-    return render_template('request.html', req=req, selected=selected, module_html=module_html)
+    modules_data = [
+        {"id": m.id, "description": m.description, "completed": m.completed}
+        for m in req.modules
+    ]
+
+    return render_template(
+        'request.html',
+        req=req,
+        selected=selected,
+        module_html=module_html,
+        modules_data=modules_data,
+    )
 
 @app.route('/module/<int:module_id>', methods=['POST'])
 def handle_module(module_id):

--- a/fastapi_app.py
+++ b/fastapi_app.py
@@ -105,9 +105,20 @@ async def view_request(request: Request, token: str, module: int | None = None, 
     )
     db.commit()
 
+    modules_data = [
+        {"id": m.id, "description": m.description, "completed": m.completed}
+        for m in req_db.modules
+    ]
+
     return templates.TemplateResponse(
         "request.html",
-        {"request": request, "req": req_db, "selected": selected, "module_html": module_html},
+        {
+            "request": request,
+            "req": req_db,
+            "selected": selected,
+            "module_html": module_html,
+            "modules_data": modules_data,
+        },
     )
 
 

--- a/static/style.css
+++ b/static/style.css
@@ -17,3 +17,18 @@ body {font-family: Arial, sans-serif;}
     margin-bottom: 1em;
     border: 1px solid #ccc;
 }
+
+.progress-container {
+    margin-top: 1em;
+}
+.progress-bar {
+    height: 8px;
+    background: #eee;
+    border-radius: 4px;
+    overflow: hidden;
+}
+.progress-fill {
+    height: 100%;
+    background: #4caf50;
+    transition: width 0.3s;
+}

--- a/templates/request.html
+++ b/templates/request.html
@@ -1,16 +1,23 @@
 {% extends 'base.html' %}
 {% block content %}
-<div class="layout" x-data="{}">
+{% set modules_json = modules_data | tojson %}
+<div class="layout" x-data="requestPage({{ modules_json|safe }})">
     <div class="queue">
         <h2>Requested Items</h2>
         <ul>
-        {% for m in req.modules %}
-            <li>
-            {% if m.completed %}&#10003;{% else %}&#9633;{% endif %}
-            <a href="{{ url_for('view_request', token=req.token) }}?module={{ m.id }}">{{ m.description }}</a>
-            </li>
-        {% endfor %}
+            <template x-for="m in modules" :key="m.id">
+                <li>
+                    <span x-text="m.completed ? '✓' : '□'"></span>
+                    <a :href="'{{ url_for('view_request', token=req.token) }}?module=' + m.id" x-text="m.description"></a>
+                </li>
+            </template>
         </ul>
+        <div class="progress-container">
+            <div class="progress-bar">
+                <div class="progress-fill" :style="{width: progress + '%'}"></div>
+            </div>
+            <p x-text="progress + '% complete'"></p>
+        </div>
         {% if req.expires_at %}
             <p class="expiration">
                 Expires {{ req.expires_at.strftime('%Y-%m-%d %H:%M UTC') }}
@@ -27,4 +34,16 @@
         {% endif %}
     </div>
 </div>
+<script>
+function requestPage(modules) {
+    return {
+        modules: modules,
+        get progress() {
+            if (this.modules.length === 0) return 100;
+            let done = this.modules.filter(m => m.completed).length;
+            return Math.round((done / this.modules.length) * 100);
+        }
+    }
+}
+</script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- compute module metadata for frontend use
- show module progress with Alpine.js on request page
- style new progress bar

## Testing
- `python -m py_compile fastapi_app.py app.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846fe59cebc8325be034100f7787200