### PR TITLE
Scaffold FastAPI app with core modules

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,1 @@
+"""FileMaster application package."""

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,27 @@
+"""Main FastAPI application."""
+
+from fastapi import FastAPI
+
+from .modules import discover_modules
+
+app = FastAPI(title="FileMaster")
+
+
+@app.on_event("startup")
+async def load_modules() -> None:
+    """Discover and initialize modules on startup."""
+    discover_modules()
+
+
+@app.get("/")
+async def root() -> dict[str, str]:
+    """Basic root endpoint."""
+    return {"message": "Welcome to FileMaster"}
+
+
+@app.get("/modules")
+async def list_modules() -> list[str]:
+    """List registered module keys."""
+    from .modules import registry
+
+    return list(registry.keys())

--- a/app/models.py
+++ b/app/models.py
@@ -1,0 +1,36 @@
+"""Database models for FileMaster."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from sqlalchemy import Column, DateTime, ForeignKey, Integer, String
+from sqlalchemy.orm import declarative_base, relationship
+
+Base = declarative_base()
+
+
+class User(Base):
+    """Application user."""
+
+    __tablename__ = "user"
+
+    id = Column(Integer, primary_key=True)
+    username = Column(String(64), unique=True, nullable=False)
+    created_at = Column(DateTime, default=datetime.utcnow)
+
+    requests = relationship("ClientRequest", back_populates="creator")
+
+
+class ClientRequest(Base):
+    """Main request entity."""
+
+    __tablename__ = "client_request"
+
+    id = Column(Integer, primary_key=True)
+    token = Column(String(64), unique=True, nullable=False, index=True)
+    nickname = Column(String(128))
+    creator_id = Column(Integer, ForeignKey("user.id"))
+    created_at = Column(DateTime, default=datetime.utcnow)
+
+    creator = relationship("User", back_populates="requests")

--- a/app/modules/__init__.py
+++ b/app/modules/__init__.py
@@ -1,0 +1,46 @@
+"""Module discovery and registry."""
+
+from __future__ import annotations
+
+import importlib
+import pkgutil
+from typing import Dict, Type
+
+from pydantic import BaseModel
+
+
+class ModuleHandler:
+    """Minimal interface for module handlers."""
+
+    key: str
+    name: str
+
+    def get_fields(self) -> list[BaseModel]:
+        raise NotImplementedError
+
+    def validate(self, data: dict) -> dict:
+        raise NotImplementedError
+
+    def save(self, request: "ClientRequest", data: dict) -> None:
+        raise NotImplementedError
+
+
+registry: Dict[str, ModuleHandler] = {}
+
+
+def discover_modules() -> None:
+    """Discover and register modules available in the modules package."""
+    global registry
+    registry.clear()
+    package = __name__
+    for finder, name, ispkg in pkgutil.iter_modules(__path__):
+        if not ispkg:
+            continue
+        module_name = f"{package}.{name}.handler"
+        try:
+            module = importlib.import_module(module_name)
+        except ImportError:
+            continue
+        handler = getattr(module, "handler", None)
+        if handler and hasattr(handler, "key"):
+            registry[handler.key] = handler

--- a/app/modules/sample_module/__init__.py
+++ b/app/modules/sample_module/__init__.py
@@ -1,0 +1,1 @@
+"""Sample module package."""

--- a/app/modules/sample_module/handler.py
+++ b/app/modules/sample_module/handler.py
@@ -1,0 +1,30 @@
+"""Sample module handler implementation."""
+
+from pydantic import BaseModel, Field
+
+from ..models import ClientRequest
+from ..modules import ModuleHandler
+
+
+class SampleModel(BaseModel):
+    """Schema for sample module fields."""
+
+    text: str = Field(..., title="Sample Text")
+
+
+class SampleModuleHandler(ModuleHandler):
+    key = "sample"
+    name = "Sample Module"
+
+    def get_fields(self) -> list[BaseModel]:
+        return [SampleModel]
+
+    def validate(self, data: dict) -> dict:
+        return SampleModel(**data).dict()
+
+    def save(self, request: ClientRequest, data: dict) -> None:
+        # Placeholder: In a real module, persist data to DB or filesystem
+        print(f"Saving data for request {request.id}: {data}")
+
+
+handler = SampleModuleHandler()

--- a/app/utils/database.py
+++ b/app/utils/database.py
@@ -1,0 +1,16 @@
+"""Database configuration utilities."""
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from ..models import Base
+
+DATABASE_URL = "sqlite:///./filemaster.db"
+
+engine = create_engine(DATABASE_URL, future=True)
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine, future=True)
+
+
+def init_db() -> None:
+    """Initialize database tables."""
+    Base.metadata.create_all(bind=engine)

--- a/app/utils/encryption.py
+++ b/app/utils/encryption.py
@@ -1,0 +1,18 @@
+"""Simple encryption utilities using Fernet."""
+
+from cryptography.fernet import Fernet
+
+
+def generate_key() -> bytes:
+    """Generate a new encryption key."""
+    return Fernet.generate_key()
+
+
+def encrypt(value: str, key: bytes) -> bytes:
+    """Encrypt a string value."""
+    return Fernet(key).encrypt(value.encode())
+
+
+def decrypt(token: bytes, key: bytes) -> str:
+    """Decrypt an encrypted value."""
+    return Fernet(key).decrypt(token).decode()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,19 @@
+[tool.poetry]
+name = "filemaster"
+version = "0.1.0"
+description = "Modular customer document collection platform"
+authors = ["Auto AI <ai@example.com>"]
+
+[tool.poetry.dependencies]
+python = "^3.10"
+fastapi = "*"
+uvicorn = "*"
+SQLAlchemy = "*"
+cryptography = "*"
+
+[tool.poetry.dev-dependencies]
+pytest = "*"
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
## Summary
- initialize FastAPI project structure
- implement module discovery system
- add sample module for demonstration
- set up SQLAlchemy models and database helpers
- include simple encryption utilities

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684791b70b0c8325844efa39a4dff0ae