### PR TITLE
Fix poetry deprecation warning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ uvicorn = "*"
 SQLAlchemy = "*"
 cryptography = "*"
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 pytest = "*"
 
 [build-system]


### PR DESCRIPTION
## Summary
- switch to `[tool.poetry.group.dev.dependencies]` for dev deps

## Testing
- `poetry install --no-root`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684795b4e79c8325b87c62b1574a3c51