### PR TITLE
Add module models and API endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+poetry.lock

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,8 @@ FileMaster v2.0 is a modular customer document collection platform designed for 
 - **Framework**: FastAPI (Python)
 - **Database**: SQLAlchemy with PostgreSQL (production) / SQLite (development)
 - **File Storage**: Local filesystem with organized directory structure
+- **File Operations**: Central orchestrator handles uploads, downloads and deletions;
+  modules never access the filesystem directly
 - **Background Tasks**: APScheduler for cleanup and maintenance
 - **Migrations**: Alembic for database schema management
 
@@ -165,6 +167,9 @@ class AccessLog(Base):
     action = Column(String(50))  # 'view', 'submit', 'download', 'edit'
     timestamp = Column(DateTime, default=datetime.utcnow)
 ```
+
+Modules do not create their own tables; this generic model combined with JSON
+fields supports all module data and configuration.
 
 ## Module System Specifications
 
@@ -420,6 +425,8 @@ uploads/
 - Orphaned file cleanup
 - Storage usage monitoring
 - Backup before deletion (optional)
+- Modules perform all file operations through the orchestrator rather than
+  direct filesystem access
 
 ## Data Security & Privacy
 

--- a/app/main.py
+++ b/app/main.py
@@ -1,16 +1,54 @@
 """Main FastAPI application."""
 
-from fastapi import FastAPI
+from fastapi import FastAPI, Depends, HTTPException
+from pydantic import BaseModel
+from sqlalchemy.orm import Session
+from secrets import token_hex
 
 from .modules import discover_modules
+from .models import ClientRequest, Module
+from .utils.database import SessionLocal, init_db
 
 app = FastAPI(title="FileMaster")
+
+
+def get_db() -> Session:
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+class RequestCreate(BaseModel):
+    nickname: str | None = None
+
+
+class ModuleAttach(BaseModel):
+    kind: str
+    label: str | None = None
+    description: str | None = None
+    required: bool = True
+
+
+class ModuleStatus(BaseModel):
+    id: int
+    kind: str
+    label: str | None
+    completed: bool
+
+
+class RequestStatus(BaseModel):
+    id: int
+    token: str
+    modules: list[ModuleStatus]
 
 
 @app.on_event("startup")
 async def load_modules() -> None:
     """Discover and initialize modules on startup."""
     discover_modules()
+    init_db()
 
 
 @app.get("/")
@@ -25,3 +63,49 @@ async def list_modules() -> list[str]:
     from .modules import registry
 
     return list(registry.keys())
+
+
+@app.post("/requests", response_model=RequestStatus)
+def create_request(data: RequestCreate, db: Session = Depends(get_db)):
+    req = ClientRequest(token=token_hex(16), nickname=data.nickname)
+    db.add(req)
+    db.commit()
+    db.refresh(req)
+    return RequestStatus(id=req.id, token=req.token, modules=[])
+
+
+@app.post("/requests/{request_id}/modules", response_model=ModuleStatus)
+def attach_module(request_id: int, data: ModuleAttach, db: Session = Depends(get_db)):
+    req = db.get(ClientRequest, request_id)
+    if not req:
+        raise HTTPException(status_code=404, detail="Request not found")
+    module = Module(
+        request=req,
+        kind=data.kind,
+        label=data.label,
+        description=data.description,
+        required=data.required,
+    )
+    db.add(module)
+    db.commit()
+    db.refresh(module)
+    return ModuleStatus(
+        id=module.id, kind=module.kind, label=module.label, completed=module.completed
+    )
+
+
+@app.get("/requests/{request_id}", response_model=RequestStatus)
+def get_request(request_id: int, db: Session = Depends(get_db)):
+    req = db.get(ClientRequest, request_id)
+    if not req:
+        raise HTTPException(status_code=404, detail="Request not found")
+    modules = [
+        ModuleStatus(
+            id=m.id,
+            kind=m.kind,
+            label=m.label,
+            completed=m.completed,
+        )
+        for m in req.modules
+    ]
+    return RequestStatus(id=req.id, token=req.token, modules=modules)

--- a/app/models.py
+++ b/app/models.py
@@ -4,7 +4,16 @@ from __future__ import annotations
 
 from datetime import datetime
 
-from sqlalchemy import Column, DateTime, ForeignKey, Integer, String
+from sqlalchemy import (
+    Boolean,
+    Column,
+    DateTime,
+    ForeignKey,
+    Integer,
+    JSON,
+    String,
+    Text,
+)
 from sqlalchemy.orm import declarative_base, relationship
 
 Base = declarative_base()
@@ -32,5 +41,60 @@ class ClientRequest(Base):
     nickname = Column(String(128))
     creator_id = Column(Integer, ForeignKey("user.id"))
     created_at = Column(DateTime, default=datetime.utcnow)
+    expires_at = Column(DateTime)
+    completed_at = Column(DateTime)
+    last_accessed = Column(DateTime)
+    metadata = Column(JSON, default=dict)
 
     creator = relationship("User", back_populates="requests")
+    modules = relationship(
+        "Module", back_populates="request", cascade="all, delete-orphan"
+    )
+    access_logs = relationship(
+        "AccessLog", back_populates="request", cascade="all, delete-orphan"
+    )
+
+
+class Module(Base):
+    """Generic module instance."""
+
+    __tablename__ = "module"
+
+    id = Column(Integer, primary_key=True)
+    request_id = Column(Integer, ForeignKey("client_request.id"), nullable=False)
+    kind = Column(String(50), nullable=False)
+    label = Column(String(255))
+    description = Column(Text)
+    sort_order = Column(Integer, default=0)
+    required = Column(Boolean, default=True)
+    completed = Column(Boolean, default=False)
+    completed_at = Column(DateTime)
+
+    result_data = Column(JSON, default=dict)
+    config = Column(JSON, default=dict)
+    allow_edit = Column(Boolean, default=False)
+    show_previous = Column(Boolean, default=True)
+    expires_at = Column(DateTime)
+
+    version = Column(Integer, default=1)
+    edit_history = Column(JSON, default=list)
+
+    request = relationship("ClientRequest", back_populates="modules")
+    access_logs = relationship("AccessLog", back_populates="module")
+
+
+class AccessLog(Base):
+    """Security and analytics logging."""
+
+    __tablename__ = "access_log"
+
+    id = Column(Integer, primary_key=True)
+    request_id = Column(Integer, ForeignKey("client_request.id"))
+    module_id = Column(Integer, ForeignKey("module.id"), nullable=True)
+    ip_address = Column(String(64))
+    user_agent = Column(String(255))
+    action = Column(String(50))
+    timestamp = Column(DateTime, default=datetime.utcnow)
+
+    request = relationship("ClientRequest", back_populates="access_logs")
+    module = relationship("Module", back_populates="access_logs")


### PR DESCRIPTION
## Summary
- document orchestrated file handling
- clarify generic module table usage
- model `Module` and `AccessLog`
- initialize database on startup
- create request and module APIs

## Testing
- `pytest -q`
- `black --check .`
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684795cfc2148325a07291ec53ec9299