### PR TITLE
Add environment-based configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,4 +26,5 @@ poetry run uvicorn app.main:app --reload
 This will start the API on `http://localhost:8000`.
 
 See [docs/setup.md](docs/setup.md) for configuration via environment variables.
+Default values are provided for development, so a `.env` file is optional.
 

--- a/README.md
+++ b/README.md
@@ -25,3 +25,5 @@ poetry run uvicorn app.main:app --reload
 
 This will start the API on `http://localhost:8000`.
 
+See [docs/setup.md](docs/setup.md) for configuration via environment variables.
+

--- a/app/main.py
+++ b/app/main.py
@@ -48,7 +48,7 @@ class RequestStatus(BaseModel):
 settings: Settings
 
 
-async def load_modules() -> None:
+def load_modules() -> None:
     """Discover modules and initialize the database."""
     discover_modules()
     init_db()
@@ -60,7 +60,7 @@ async def startup_event() -> None:
     global settings
     settings = Settings()
     app.state.settings = settings
-    await load_modules()
+    load_modules()
 
 
 @app.get("/")

--- a/app/main.py
+++ b/app/main.py
@@ -48,14 +48,19 @@ class RequestStatus(BaseModel):
 settings: Settings
 
 
+async def load_modules() -> None:
+    """Discover modules and initialize the database."""
+    discover_modules()
+    init_db()
+
+
 @app.on_event("startup")
 async def startup_event() -> None:
-    """Load configuration and initialize modules and database."""
+    """Load configuration and then initialize modules."""
     global settings
     settings = Settings()
     app.state.settings = settings
-    discover_modules()
-    init_db()
+    await load_modules()
 
 
 @app.get("/")

--- a/app/main.py
+++ b/app/main.py
@@ -8,6 +8,7 @@ from secrets import token_hex
 from .modules import discover_modules
 from .models import ClientRequest, Module
 from .utils.database import SessionLocal, init_db
+from .settings import Settings
 
 app = FastAPI(title="FileMaster")
 
@@ -44,9 +45,15 @@ class RequestStatus(BaseModel):
     modules: list[ModuleStatus]
 
 
+settings: Settings
+
+
 @app.on_event("startup")
-async def load_modules() -> None:
-    """Discover and initialize modules on startup."""
+async def startup_event() -> None:
+    """Load configuration and initialize modules and database."""
+    global settings
+    settings = Settings()
+    app.state.settings = settings
     discover_modules()
     init_db()
 

--- a/app/settings.py
+++ b/app/settings.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from typing import Set
+
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class Settings(BaseSettings):
+    """Application configuration loaded from environment variables."""
+
+    # Core settings
+    SECRET_KEY: str
+    ENCRYPTION_KEY: str
+    DATABASE_URL: str = "sqlite:///./filemaster.db"
+
+    # File handling
+    UPLOAD_FOLDER: str = "uploads"
+    MAX_FILE_SIZE: int = 10 * 1024 * 1024  # 10MB
+    ALLOWED_EXTENSIONS: Set[str] = {"pdf", "png", "jpg", "jpeg", "gif", "heic"}
+
+    # Security
+    SESSION_TIMEOUT: int = 7200  # 2 hours
+    TOKEN_EXPIRY_DAYS: int = 7
+    CLEANUP_GRACE_HOURS: int = 48
+
+    # Rate limiting
+    RATE_LIMIT_REQUESTS: int = 100
+    RATE_LIMIT_WINDOW: int = 3600  # 1 hour
+
+    # Business rules
+    MAX_MODULES_PER_REQUEST: int = 20
+    DEFAULT_REQUEST_EXPIRY_DAYS: int = 7
+
+    model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8")

--- a/app/settings.py
+++ b/app/settings.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Set
 
-from pydantic import BaseSettings
+from pydantic_settings import BaseSettings
 
 
 class Settings(BaseSettings):

--- a/app/settings.py
+++ b/app/settings.py
@@ -9,8 +9,8 @@ class Settings(BaseSettings):
     """Application configuration loaded from environment variables."""
 
     # Core settings
-    SECRET_KEY: str
-    ENCRYPTION_KEY: str
+    SECRET_KEY: str = "insecure-development-key"
+    ENCRYPTION_KEY: str = "insecure-development-encryption-key"
     DATABASE_URL: str = "sqlite:///./filemaster.db"
 
     # File handling

--- a/app/settings.py
+++ b/app/settings.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Set
 
-from pydantic_settings import BaseSettings, SettingsConfigDict
+from pydantic import BaseSettings
 
 
 class Settings(BaseSettings):
@@ -31,8 +31,7 @@ class Settings(BaseSettings):
     MAX_MODULES_PER_REQUEST: int = 20
     DEFAULT_REQUEST_EXPIRY_DAYS: int = 7
 
-    model_config = SettingsConfigDict(
-        env_file=".env",
-        env_file_encoding="utf-8",
-    )
+    class Config:
+        env_file = ".env"
+        env_file_encoding = "utf-8"
 

--- a/app/settings.py
+++ b/app/settings.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Set
 
-from pydantic_settings import BaseSettings, SettingsConfigDict
+from pydantic import BaseSettings
 
 
 class Settings(BaseSettings):
@@ -31,4 +31,8 @@ class Settings(BaseSettings):
     MAX_MODULES_PER_REQUEST: int = 20
     DEFAULT_REQUEST_EXPIRY_DAYS: int = 7
 
-    model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8")
+    model_config = BaseSettings.ConfigDict(
+        env_file=".env",
+        env_file_encoding="utf-8",
+    )
+

--- a/app/settings.py
+++ b/app/settings.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Set
 
-from pydantic import BaseSettings
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 class Settings(BaseSettings):
@@ -31,7 +31,7 @@ class Settings(BaseSettings):
     MAX_MODULES_PER_REQUEST: int = 20
     DEFAULT_REQUEST_EXPIRY_DAYS: int = 7
 
-    model_config = BaseSettings.ConfigDict(
+    model_config = SettingsConfigDict(
         env_file=".env",
         env_file_encoding="utf-8",
     )

--- a/app/utils/database.py
+++ b/app/utils/database.py
@@ -6,9 +6,7 @@ from sqlalchemy.orm import sessionmaker
 from ..models import Base
 from ..settings import Settings
 
-settings = Settings()
-
-engine = create_engine(settings.DATABASE_URL, future=True)
+engine = create_engine(Settings().DATABASE_URL, future=True)
 SessionLocal = sessionmaker(
     autocommit=False,
     autoflush=False,

--- a/app/utils/database.py
+++ b/app/utils/database.py
@@ -4,10 +4,11 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
 from ..models import Base
+from ..settings import Settings
 
-DATABASE_URL = "sqlite:///./filemaster.db"
+settings = Settings()
 
-engine = create_engine(DATABASE_URL, future=True)
+engine = create_engine(settings.DATABASE_URL, future=True)
 SessionLocal = sessionmaker(
     autocommit=False,
     autoflush=False,

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -1,0 +1,21 @@
+# Environment Setup
+
+The application uses environment variables for configuration. Create a `.env` file or set the variables in your environment before starting the server.
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `SECRET_KEY` | Secret key used for cryptographic operations | - |
+| `ENCRYPTION_KEY` | Key used by the encryption utilities | - |
+| `DATABASE_URL` | Database connection string | `sqlite:///./filemaster.db` |
+| `UPLOAD_FOLDER` | Directory for uploaded files | `uploads` |
+| `MAX_FILE_SIZE` | Maximum allowed upload size in bytes | `10485760` |
+| `ALLOWED_EXTENSIONS` | Allowed file extensions | `{"pdf","png","jpg","jpeg","gif","heic"}` |
+| `SESSION_TIMEOUT` | Session timeout in seconds | `7200` |
+| `TOKEN_EXPIRY_DAYS` | Days before request tokens expire | `7` |
+| `CLEANUP_GRACE_HOURS` | Hours before cleanup tasks remove data | `48` |
+| `RATE_LIMIT_REQUESTS` | Number of requests allowed per window | `100` |
+| `RATE_LIMIT_WINDOW` | Rate limit window in seconds | `3600` |
+| `MAX_MODULES_PER_REQUEST` | Maximum modules attached to a request | `20` |
+| `DEFAULT_REQUEST_EXPIRY_DAYS` | Default request expiry in days | `7` |
+
+These settings are loaded via the `Settings` class in `app/settings.py` on application startup.

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -1,7 +1,7 @@
 # Environment Setup
 
 The application uses environment variables for configuration. Create a `.env` file or set the variables in your environment before starting the server.
-The server requires the `pydantic` and `pydantic-settings` packages for configuration management. These are installed automatically when running `poetry install`.
+The configuration system relies on the `pydantic` package, which is installed automatically when running `poetry install`.
 
 | Variable | Description | Default |
 |----------|-------------|---------|

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -5,8 +5,8 @@ The configuration system relies on the `pydantic-settings` package (along with `
 
 | Variable | Description | Default |
 |----------|-------------|---------|
-| `SECRET_KEY` | Secret key used for cryptographic operations | - |
-| `ENCRYPTION_KEY` | Key used by the encryption utilities | - |
+| `SECRET_KEY` | Secret key used for cryptographic operations | `insecure-development-key` |
+| `ENCRYPTION_KEY` | Key used by the encryption utilities | `insecure-development-encryption-key` |
 | `DATABASE_URL` | Database connection string | `sqlite:///./filemaster.db` |
 | `UPLOAD_FOLDER` | Directory for uploaded files | `uploads` |
 | `MAX_FILE_SIZE` | Maximum allowed upload size in bytes | `10485760` |

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -1,6 +1,7 @@
 # Environment Setup
 
 The application uses environment variables for configuration. Create a `.env` file or set the variables in your environment before starting the server.
+The server requires the `pydantic` and `pydantic-settings` packages for configuration management. These are installed automatically when running `poetry install`.
 
 | Variable | Description | Default |
 |----------|-------------|---------|

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -1,7 +1,7 @@
 # Environment Setup
 
 The application uses environment variables for configuration. Create a `.env` file or set the variables in your environment before starting the server.
-The configuration system relies on the `pydantic` package, which is installed automatically when running `poetry install`.
+The configuration system relies on the `pydantic-settings` package (along with `pydantic`), which is installed automatically when running `poetry install`.
 
 | Variable | Description | Default |
 |----------|-------------|---------|

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,6 @@ uvicorn = "*"
 SQLAlchemy = "*"
 cryptography = "*"
 pydantic = "*"
-pydantic-settings = "*"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ uvicorn = "*"
 SQLAlchemy = "*"
 cryptography = "*"
 pydantic = "*"
+pydantic-settings = "*"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ fastapi = "*"
 uvicorn = "*"
 SQLAlchemy = "*"
 cryptography = "*"
+pydantic = "*"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "*"


### PR DESCRIPTION
## Summary
- add `Settings` class for environment configuration
- load `Settings` at application startup and expose via `app.state`
- use settings in database utility
- document available environment variables

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847b2f666508325b2578c4bbf4e35b2