### PR TITLE
Add SSN module with encryption support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 poetry.lock
+__pycache__/
+*.py[cod]
+

--- a/app/modules/sample_module/handler.py
+++ b/app/modules/sample_module/handler.py
@@ -2,8 +2,8 @@
 
 from pydantic import BaseModel, Field
 
-from ..models import ClientRequest
-from ..modules import ModuleHandler
+from ...models import ClientRequest
+from .. import ModuleHandler
 
 
 class SampleModel(BaseModel):

--- a/app/modules/ssn/__init__.py
+++ b/app/modules/ssn/__init__.py
@@ -1,0 +1,1 @@
+"""Social Security Number module package."""

--- a/app/modules/ssn/handler.py
+++ b/app/modules/ssn/handler.py
@@ -1,0 +1,35 @@
+"""Handler for the SSN module."""
+
+from pydantic import BaseModel, Field
+
+from ...models import ClientRequest
+from .. import ModuleHandler
+from ...settings import Settings
+from ...utils import encryption
+
+
+class SSNModel(BaseModel):
+    """Schema for an SSN field."""
+
+    ssn: str = Field(
+        ..., title="Social Security Number", pattern=r"^\d{3}-\d{2}-\d{4}$"
+    )
+
+
+class SSNModuleHandler(ModuleHandler):
+    key = "ssn"
+    name = "Social Security Number"
+
+    def get_fields(self) -> list[BaseModel]:
+        return [SSNModel]
+
+    def validate(self, data: dict) -> dict:
+        return SSNModel(**data).dict()
+
+    def save(self, request: ClientRequest, data: dict) -> None:
+        key = Settings().ENCRYPTION_KEY.encode()
+        encrypted = encryption.encrypt(data["ssn"], key)
+        data["ssn"] = encrypted.decode()
+
+
+handler = SSNModuleHandler()

--- a/app/modules/ssn/test_ssn_module.py
+++ b/app/modules/ssn/test_ssn_module.py
@@ -1,0 +1,22 @@
+from app.modules import discover_modules, registry
+from app.utils import encryption
+
+
+def test_ssn_module_registered():
+    discover_modules()
+    assert "ssn" in registry
+
+
+def test_ssn_save_encrypted(monkeypatch):
+    key = encryption.generate_key()
+    monkeypatch.setenv("ENCRYPTION_KEY", key.decode())
+    discover_modules()
+    handler = registry["ssn"]
+
+    data = {"ssn": "123-45-6789"}
+    validated = handler.validate(data)
+    handler.save(None, validated)
+
+    assert validated["ssn"] != data["ssn"]
+    decrypted = encryption.decrypt(validated["ssn"].encode(), key)
+    assert decrypted == data["ssn"]


### PR DESCRIPTION
## Summary
- create SSN module with encrypted storage
- fix relative imports for module discovery
- register SSN module via discovery
- add tests for module registration and encryption behaviour
- ignore `__pycache__` files
- move SSN tests inside the module directory

## Testing
- `pip install pydantic pydantic-settings fastapi uvicorn SQLAlchemy cryptography --quiet`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6847bf0e4c888325ab9ba76ece735555