### PR TITLE
Add data viewer utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,16 @@ This will start the API on `http://localhost:8000`.
 See [docs/setup.md](docs/setup.md) for configuration via environment variables.
 Default values are provided for development, so a `.env` file is optional.
 
+
+## Data Viewer
+
+The utility `app/utils/data_viewer.py` helps inspect stored module data.
+Use it from an interactive Python session:
+
+```python
+from app.utils import get_request_data, get_module_data
+# View all module results for a request
+print(get_request_data(db, request_id))
+# View a single module's stored result
+print(get_module_data(db, module_id))
+```

--- a/app/utils/__init__.py
+++ b/app/utils/__init__.py
@@ -1,0 +1,16 @@
+"""Utility package providing encryption, DB setup, and data inspection."""
+
+from .database import SessionLocal, engine, init_db
+from .encryption import decrypt, encrypt, generate_key
+from .data_viewer import get_module_data, get_request_data
+
+__all__ = [
+    "SessionLocal",
+    "engine",
+    "init_db",
+    "decrypt",
+    "encrypt",
+    "generate_key",
+    "get_module_data",
+    "get_request_data",
+]

--- a/app/utils/data_viewer.py
+++ b/app/utils/data_viewer.py
@@ -1,0 +1,26 @@
+"""Utility functions to inspect stored module data."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from sqlalchemy.orm import Session
+
+from ..models import Module
+
+
+def get_module_data(db: Session, module_id: int) -> Dict[str, Any] | None:
+    """Return the stored ``result_data`` for a module by ID."""
+    module = db.get(Module, module_id)
+    return module.result_data if module else None
+
+
+def get_request_data(db: Session, request_id: int) -> Dict[int, Dict[str, Any]]:
+    """Return a mapping of module ID to ``result_data`` for a request."""
+    modules = (
+        db.query(Module)
+        .filter(Module.request_id == request_id)
+        .order_by(Module.sort_order)
+        .all()
+    )
+    return {mod.id: mod.result_data for mod in modules}

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -20,3 +20,16 @@ The configuration system relies on the `pydantic-settings` package (along with `
 | `DEFAULT_REQUEST_EXPIRY_DAYS` | Default request expiry in days | `7` |
 
 These settings are loaded via the `Settings` class in `app/settings.py` on application startup.
+
+## Data Viewer
+
+For troubleshooting, you can inspect stored module data directly using the
+`data_viewer` utilities:
+
+```python
+from app.utils import get_module_data, get_request_data
+```
+
+Both functions require a SQLAlchemy `Session` instance. Pass a request ID to
+`get_request_data` to retrieve all module results for that request, or a module
+ID to `get_module_data` for a specific module's data.


### PR DESCRIPTION
## Summary
- add `data_viewer.py` with helper functions to read stored module results
- expose new utilities in `app/utils/__init__.py`
- document how to use the data viewer in `README.md` and `docs/setup.md`

## Testing
- `pytest`
- `black app/utils/data_viewer.py app/utils/__init__.py`

------
https://chatgpt.com/codex/tasks/task_e_6847c05d575083258c3778015f72bb77