### PR TITLE
Update SSN module save signature

### DIFF
--- a/app/modules/ssn/handler.py
+++ b/app/modules/ssn/handler.py
@@ -6,6 +6,7 @@ from ...models import ClientRequest
 from .. import ModuleHandler
 from ...settings import Settings
 from ...utils import encryption
+from ...utils.file_orchestrator import FileOrchestrator
 
 
 class SSNModel(BaseModel):
@@ -26,7 +27,12 @@ class SSNModuleHandler(ModuleHandler):
     def validate(self, data: dict) -> dict:
         return SSNModel(**data).dict()
 
-    def save(self, request: ClientRequest, data: dict) -> None:
+    def save(
+        self,
+        request: ClientRequest,
+        data: dict,
+        orchestrator: FileOrchestrator,
+    ) -> None:
         key = Settings().ENCRYPTION_KEY.encode()
         encrypted = encryption.encrypt(data["ssn"], key)
         data["ssn"] = encrypted.decode()

--- a/app/modules/ssn/test_ssn_module.py
+++ b/app/modules/ssn/test_ssn_module.py
@@ -1,5 +1,6 @@
 from app.modules import discover_modules, registry
 from app.utils import encryption
+from app.utils.file_orchestrator import FileOrchestrator
 
 
 def test_ssn_module_registered():
@@ -15,7 +16,8 @@ def test_ssn_save_encrypted(monkeypatch):
 
     data = {"ssn": "123-45-6789"}
     validated = handler.validate(data)
-    handler.save(None, validated)
+    dummy_orchestrator = FileOrchestrator("/tmp")
+    handler.save(None, validated, dummy_orchestrator)
 
     assert validated["ssn"] != data["ssn"]
     decrypted = encryption.decrypt(validated["ssn"].encode(), key)


### PR DESCRIPTION
## Summary
- accept `FileOrchestrator` in SSN module's `save` method
- adjust tests to use a dummy orchestrator

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847c35372b8832584ac5ab4053ea296