### PR TITLE
Add request creation frontend

### DIFF
--- a/static/js/create_request.js
+++ b/static/js/create_request.js
@@ -1,0 +1,43 @@
+async function loadModules() {
+  const resp = await fetch('/modules');
+  const modules = await resp.json();
+  const list = document.getElementById('module-list');
+  modules.forEach(m => {
+    const label = document.createElement('label');
+    label.className = 'block';
+    const checkbox = document.createElement('input');
+    checkbox.type = 'checkbox';
+    checkbox.value = m;
+    checkbox.className = 'mr-2';
+    label.appendChild(checkbox);
+    label.appendChild(document.createTextNode(m));
+    list.appendChild(label);
+  });
+}
+
+async function createRequest(event) {
+  event.preventDefault();
+  const nickname = document.getElementById('nickname').value;
+  const expires = parseInt(document.getElementById('expires').value, 10);
+
+  const res = await fetch('/requests', {
+    method: 'POST',
+    headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify({ nickname, expires_days: expires })
+  });
+  const request = await res.json();
+
+  const selected = Array.from(document.querySelectorAll('#module-list input:checked')).map(cb => cb.value);
+  for (const mod of selected) {
+    await fetch(`/requests/${request.id}/modules`, {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({ kind: mod })
+    });
+  }
+
+  alert('Request created with token: ' + request.token);
+}
+
+document.getElementById('request-form').addEventListener('submit', createRequest);
+loadModules();

--- a/static/new_request.html
+++ b/static/new_request.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Create Request</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-gray-100 p-4">
+  <div class="max-w-xl mx-auto bg-white p-6 rounded shadow">
+    <h1 class="text-xl font-bold mb-4">New Request</h1>
+    <form id="request-form" class="space-y-4">
+      <div>
+        <label class="block mb-1" for="nickname">Request Name</label>
+        <input id="nickname" class="border rounded w-full p-2" placeholder="Optional" />
+      </div>
+      <div>
+        <label class="block mb-1" for="expires">Expires in (days)</label>
+        <input id="expires" type="number" class="border rounded w-full p-2" value="7" />
+      </div>
+      <div>
+        <p class="mb-2">Modules</p>
+        <div id="module-list" class="space-y-1"></div>
+      </div>
+      <button class="bg-blue-600 text-white px-4 py-2 rounded" type="submit">Create</button>
+    </form>
+  </div>
+  <script src="/static/js/create_request.js"></script>
+</body>
+</html>

--- a/test_request.py
+++ b/test_request.py
@@ -1,0 +1,12 @@
+from fastapi.testclient import TestClient
+from app.main import app
+
+
+def test_create_request_with_expiry(tmp_path, monkeypatch):
+    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{tmp_path}/test.db")
+    client = TestClient(app)
+    with client:
+        resp = client.post("/requests", json={"nickname": "test", "expires_days": 2})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "token" in data


### PR DESCRIPTION
## Summary
- extend request creation API to allow expiration days
- add HTML/JS frontend for creating a request
- mount static files in FastAPI app
- test request creation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847c6a0f2a48325baaacdf082980149